### PR TITLE
fix(alita-core): 修复 isChildComp 方法只通过基本组件名称来判断是否需要处理成抽象节点导致的bug

### DIFF
--- a/packages/alita-core/src/tran/addTempName.js
+++ b/packages/alita-core/src/tran/addTempName.js
@@ -11,12 +11,12 @@ import * as t from "@babel/types"
 import {InnerTemplateNamePrefix} from "../constants";
 import {isJSXChild, isChildCompChild} from "../util/uast";
 import {geneOrder} from '../util/util'
-export default function addTempName (ast) {
+export default function addTempName (ast, info) {
     const go = geneOrder()
     errorLogTraverse(ast, {
         exit: path => {
             if (path.type === 'JSXElement'
-                && (!isJSXChild(path) || isChildCompChild(path))
+                && (!isJSXChild(path) || isChildCompChild(path, info.filepath))
             ) {
                 const jsxOp = path.node.openingElement
 

--- a/packages/alita-core/src/tran/childrenToTemplate.js
+++ b/packages/alita-core/src/tran/childrenToTemplate.js
@@ -98,7 +98,7 @@ export default function childrenToTemplate(ast, info) {
         exit: path => {
 
             if (path.type === 'JSXElement'
-                && !isChildComp(path.node.openingElement.name.name)
+                && !isChildComp(path.node.openingElement.name.name, info.filepath)
             ) {
                 const children = path.node.children
                 let tempName = null//`${ChildTemplateNamePrefix}${goForCTNP.next}`

--- a/packages/alita-core/src/tran/cptCompHandler.js
+++ b/packages/alita-core/src/tran/cptCompHandler.js
@@ -257,7 +257,7 @@ export default function cptCompHandler (ast, info) {
             }
 
             if (path.type === 'JSXElement'
-                && isChildComp(path.node.openingElement.name.name)
+                && isChildComp(path.node.openingElement.name.name, info.filepath)
                 && path.node.children.length > 0
             ) {
                 const pe = path.node.openingElement

--- a/packages/alita-core/src/tran/geneAllTemplate.js
+++ b/packages/alita-core/src/tran/geneAllTemplate.js
@@ -140,7 +140,7 @@ export default function(ast, info) {
 
 
             if (path.type === 'JSXElement'
-                && isChildComp(path.node.openingElement.name.name)
+                && isChildComp(path.node.openingElement.name.name, info.filepath)
             ) {
                 path.node.children = []
             }
@@ -156,7 +156,7 @@ export default function(ast, info) {
              *    若A是自定义组件，需要将其children转化为 generic：抽象节点的形式，传递出去，也需要提取为  tempName
              */
             if (path.type === 'JSXElement'
-                && (!isJSXChild(path) || isChildCompChild(path))
+                && (!isJSXChild(path) || isChildCompChild(path, info.filepath))
             ) {
                 const jsxOp = path.node.openingElement
                 let tempName = ''

--- a/packages/alita-core/src/util/uast.ts
+++ b/packages/alita-core/src/util/uast.ts
@@ -12,6 +12,8 @@ import * as t from "@babel/types"
 
 import {allBaseComp, extChildComp} from './getAndStorecompInfos'
 import {wxBaseComp} from '../constants'
+import {getModuleInfo} from './cacheModuleInfos'
+import {judgeLibPath} from './util'
 
 import configure from '../configure'
 
@@ -154,7 +156,7 @@ export function isJSXChild(path) {
  * @param name
  * @returns {boolean}
  */
-export function isChildComp(name) {
+export function isChildComp(name, filepath) {
     if (wxBaseComp.has(name) || configure.configObj.miniprogramComponents[name]) return false
 
     // 基本组件children 需要转化为childrencpt的组件
@@ -162,8 +164,10 @@ export function isChildComp(name) {
         return true
     }
 
+    const {im} = getModuleInfo(filepath)
     // 基本组件children 不需要转化为childrencpt的组件
-    if (allBaseComp.has(name)) {
+    // 通过组件名称判断还不够，还需要判断来源是否是组件库里
+    if (allBaseComp.has(name) && judgeLibPath(im[name].source)) {
         return false
     }
 
@@ -176,7 +180,7 @@ export function isChildComp(name) {
  * @param path
  * @returns {any}
  */
-export function isChildCompChild(path) {
+export function isChildCompChild(path, filepath) {
     const jc = isJSXChild(path)
     if (!jc) return false
 
@@ -184,7 +188,7 @@ export function isChildCompChild(path) {
     const name = parentElement.node.openingElement.name.name
 
 
-    return isChildComp(name)
+    return isChildComp(name, filepath)
 }
 
 /**

--- a/packages/alita-core/src/util/uast.ts
+++ b/packages/alita-core/src/util/uast.ts
@@ -166,8 +166,10 @@ export function isChildComp(name, filepath) {
 
     const {im} = getModuleInfo(filepath)
     // 基本组件children 不需要转化为childrencpt的组件
-    // 通过组件名称判断还不够，还需要判断来源是否是组件库里
-    if (allBaseComp.has(name) && judgeLibPath(im[name].source)) {
+    if (allBaseComp.has(name)) {
+        if (im[name] && !judgeLibPath(im[name].source)) {
+            console.log(`${filepath.replace(configure.inputFullpath, '')} 组件名为${name} 与 ${name}基础组件名称重复，可能会导致渲染不成功，建议将${name}重新命名！`.warn)
+        }
         return false
     }
 


### PR DESCRIPTION
isChildComp 里有一段代码，来判断是否需要将组件处理成抽象节点判断有问题，如下

```
export function isChildComp(name) {
    if (wxBaseComp.has(name) || configure.configObj.miniprogramComponents[name]) return false

    // 基本组件children 需要转化为childrencpt的组件
    if (extChildComp.has(name)) {
        return true
    }

    //************************************************//
    // 基本组件children 不需要转化为childrencpt的组件
    if (allBaseComp.has(name)) {
        return false
    }
   //************************************************//

    // 自定义组件 children都需要转化为childrencpt
    return true
}
```
上面用 //*******// 符号包起来这段代码有点问题，这里直接通过名称来判断当前节点是否是属于基本组件（base === true），如果是的话，就不将此节点处理成抽象节点，这个逻辑需要再增加一个判断，判断此节点的来源是否是属于组件库里（npm包），否则如果在业务工程里，刚好有一个节点名称和allBaseComp里一样，就会不处理成抽象节点。例如把/examples/HelloWorldRN/src/a/index.js里一段代码  import MyChildComp from './MyChildComp'  改成  import Hi from './MyChildComp'， 就会出现问题，因为 Hi 这个名称是在 @areslabs/hi-rn 包里指定为基本组件的名称，所以此时 import Hi from './MyChildComp' 就会因为  @areslabs/hi-rn 的关系不处理 MyChildComp 的节点为抽象节点，从而导致MyChildComp组件里的this.props.children代码无法渲染。

isChildComp方法需要改造如下：

```
export function isChildComp(name, filepath) {
    if (wxBaseComp.has(name) || configure.configObj.miniprogramComponents[name]) return false

    // 基本组件children 需要转化为childrencpt的组件
    if (extChildComp.has(name)) {
        return true
    }

    const {im} = getModuleInfo(filepath)
    // 基本组件children 不需要转化为childrencpt的组件
    // 通过组件名称判断还不够，还需要判断来源是否是组件库里
    if (allBaseComp.has(name) && judgeLibPath(im[name].source)) {
        return false
    }

    // 自定义组件 children都需要转化为childrencpt
    return true
}
```
