### PR TITLE
支持onLay事件

### DIFF
--- a/examples/HelloWorldRN/src/a/index.js
+++ b/examples/HelloWorldRN/src/a/index.js
@@ -177,7 +177,7 @@ export default class A extends Component {
                 {this.item2}
                 {item3}
 
-                <View style={styles.button}>
+                <View style={styles.button} onLayout={(event) => console.log('event', event.nativeEvent.layout)}>
                     <Button
                         title="CLICK ME"
                         color="#fff"

--- a/packages/alita-core/src/constants.ts
+++ b/packages/alita-core/src/constants.ts
@@ -14,6 +14,15 @@ export const ChildTemplateDataKeyPrefix = "CTDK" // inner spread attribute prefi
 
 export const ChildTemplateNamePrefix = "CTNP"
 
+export const LayoutConstsMap = {
+    LayoutEventPrefix: 'LEP',  // onLayout事件处理标识前缀
+    LayoutEventKey: 'LEP_Key', // 标识Key
+    OnLayoutEvents: 'LEP_onLayoutEvents',  // 收集所有onLayout事件的集合
+    OnLayoutIdMap: 'LEP_onLayoutIdMap',  // 记录onLayout的事件标识
+    UpdateLayoutEvents: 'LEP_updateLayoutEvents',  // 触发onLayout事件方法
+    CollectOnLayoutEvent: 'LEP_collectOnLayoutEvent',  // 收集onLayout事件方法
+}
+
 // 由 ./util/getAndStorecompInfos 根据package.json相关配置构造
 export const RNCOMPSET = new Set([])
 

--- a/packages/alita-core/src/precheck/checkJSX.ts
+++ b/packages/alita-core/src/precheck/checkJSX.ts
@@ -34,7 +34,6 @@ const supportRNAPI = new Set([
 ])
 
 const notSupportCommonAttris = new Set([
-    'onLayout',
     'onStartShouldSetResponder',
     'onMoveShouldSetResponder',
     'onResponderGrant',

--- a/packages/alita-core/src/tran/index.ts
+++ b/packages/alita-core/src/tran/index.ts
@@ -7,6 +7,7 @@
  */
 
 import {geneReactCode} from '../util/uast'
+import onLayoutHandler from './onLayoutHandler'
 import funcCompToClassComp from './funcCompToClassComp'
 import childrenToTemplate from './childrenToTemplate'
 import compPreHandle from './compPreHandle'
@@ -40,6 +41,8 @@ export default function (ast, filepath, isFuncComp, isPageComp, webpackContext) 
 
         //webpackContext,
     }
+
+    ast = onLayoutHandler(ast, info)
 
     ast = funcCompToClassComp(ast, info)
 

--- a/packages/alita-core/src/tran/onLayoutHandler.ts
+++ b/packages/alita-core/src/tran/onLayoutHandler.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Areslabs.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+ /**
+ * 收集 JSX 中的所有 onLayout 事件
+ * @param ast
+ * @param info
+ * @returns {*}
+ */
+
+import errorLogTraverse from '../util/ErrorLogTraverse'
+import {LayoutConstsMap} from '../constants'
+import * as t from "@babel/types"
+
+let id = 1
+
+export default function onLayoutHandler (ast, info) {
+    let hasOnLayoutAttr = false
+
+    errorLogTraverse(ast, {
+        enter: path => {
+            if (path.type === 'JSXOpeningElement') {
+                const attris = path.node.attributes
+                const onLayoutAttr = attris.filter(item => item.type === 'JSXAttribute' 
+                                                && item.name.type === 'JSXIdentifier' 
+                                                && item.name.name === 'onLayout'
+                                                && item.value.type === 'JSXExpressionContainer')
+
+                if (onLayoutAttr && onLayoutAttr.length)  {
+                    hasOnLayoutAttr = true
+                    const elementId = `${LayoutConstsMap.LayoutEventPrefix}_${id++}`
+                    attris.push(
+                        t.jsxAttribute(t.jsxIdentifier(LayoutConstsMap.LayoutEventKey), t.stringLiteral(elementId))
+                    )
+                    attris.push(
+                        t.jsxAttribute(
+                            t.jsxIdentifier(LayoutConstsMap.CollectOnLayoutEvent), 
+                            t.jsxExpressionContainer(
+                                t.callExpression(
+                                    t.memberExpression(
+                                        t.memberExpression(
+                                            t.thisExpression(),
+                                            t.identifier(LayoutConstsMap.CollectOnLayoutEvent)
+                                        ),
+                                        t.identifier('bind')
+                                    ),
+                                    [t.thisExpression()]
+                                )
+                            )
+                        )
+                    )
+                }
+            }
+
+        },
+
+        exit: path => {
+            if (path.type === 'ClassBody' && hasOnLayoutAttr) {
+                path.node.body.push(
+                    t.classMethod(
+                        'method', 
+                        t.identifier(LayoutConstsMap.CollectOnLayoutEvent), 
+                        [t.identifier('event')], 
+                        t.blockStatement([
+                            t.expressionStatement(
+                                t.callExpression(
+                                    t.memberExpression(
+                                        t.identifier('wx'),
+                                        t.identifier(LayoutConstsMap.CollectOnLayoutEvent)
+                                    ),
+                                    [t.identifier('event'), t.thisExpression()]
+                                )
+                            ) 
+                        ])
+                    )
+                )
+                path.node.body.push(
+                    t.classMethod(
+                        'method',
+                        t.identifier(LayoutConstsMap.UpdateLayoutEvents),
+                        [], 
+                        t.blockStatement([
+                            t.expressionStatement(
+                                t.callExpression(
+                                    t.memberExpression(
+                                        t.identifier('wx'),
+                                        t.identifier(LayoutConstsMap.UpdateLayoutEvents)
+                                    ),
+                                    [t.thisExpression()]
+                                )
+                            ) 
+                        ])
+                    )
+                )
+            }
+        }
+
+    })
+    return ast
+}

--- a/packages/wx-react/src/UpdateStrategy.js
+++ b/packages/wx-react/src/UpdateStrategy.js
@@ -14,6 +14,7 @@ import {resetEffect} from "./effect";
 import instanceManager from "./InstanceManager";
 import getChangePath from './getChangePath'
 import {HocComponent} from './AllComponent'
+import {LayoutConstsMap} from './constants'
 
 let inRenderPhase = false
 let shouldMerge = false
@@ -21,6 +22,16 @@ let shouldMerge = false
 export let oldChildren = []
 
 export function performUpdater(inst, updater) {
+    // 如果有onLayout事件的话，则在setState回掉后执行一下
+    if (inst[LayoutConstsMap.UpdateLayoutEvents]) {
+        const callback = updater.callback
+        updater.callback = function() {
+            inst[LayoutConstsMap.UpdateLayoutEvents].call(inst)
+            if (callback) {
+                callback.call(inst)
+            }
+        }
+    }
     inst.updateQueue.push(updater)
 
     setUpdateTagToRoot(inst)

--- a/packages/wx-react/src/WxNormalComp.js
+++ b/packages/wx-react/src/WxNormalComp.js
@@ -9,7 +9,7 @@
 import {renderPage, createElement, HocComponent, unstable_batchedUpdates, instanceManager} from "./index"
 import geneUUID from "./geneUUID"
 import {cleanPageComp} from './util'
-
+import {LayoutConstsMap} from './constants'
 
 export default function (compPath) {
 
@@ -21,6 +21,14 @@ export default function (compPath) {
         attached() {
             // 页面组件 这个时候diuu 还未准备好
             this.data.diuu && instanceManager.setWxCompInst(this.data.diuu, this)
+        },
+
+        ready() {
+            const compInst = instanceManager.getCompInstByUUID(this.data.diuu)
+            // 处理onLayout事件
+            if (compInst && compInst[LayoutConstsMap.UpdateLayoutEvents]) {
+                compInst[LayoutConstsMap.UpdateLayoutEvents].call(compInst)
+            }
         },
 
 
@@ -81,6 +89,10 @@ export default function (compPath) {
                     )
 
                     const compInst = instanceManager.getCompInstByUUID(this.data.diuu)
+                    // 处理onLayout事件
+                    if (compInst[LayoutConstsMap.UpdateLayoutEvents]) {
+                        compInst[LayoutConstsMap.UpdateLayoutEvents].call(compInst)
+                    }
                     //如果组件还未初始化 didFocus方法，保证执行顺序为： didMount --> didFocus
                     if (compInst.componentDidFocus) {
                         const focusFunc = compInst.componentDidFocus

--- a/packages/wx-react/src/constants.js
+++ b/packages/wx-react/src/constants.js
@@ -25,3 +25,12 @@ export const mpRoot = {
     _c: []
 }
 
+export const LayoutConstsMap = {
+    LayoutEventPrefix: 'LEP',  // onLayout 事件处理标识前缀
+    LayoutEventKey: 'LEP_Key', // 标识Key
+    OnLayoutEvents: 'LEP_onLayoutEvents',  // 收集所有onLayout事件的集合
+    OnLayoutIdMap: 'LEP_onLayoutIdMap',  // 记录onLayout的事件标识
+    UpdateLayoutEvents: 'LEP_updateLayoutEvents',  // 触发onLayout事件方法
+    CollectOnLayoutEvent: 'LEP_collectOnLayoutEvent',  // 收集onLayout事件方法
+}
+

--- a/packages/wx-react/src/createElement.js
+++ b/packages/wx-react/src/createElement.js
@@ -7,6 +7,7 @@
  */
 
 // 一般情况下 uuid都应该是存在的， 但是HOC的包裹的组件，uuid需要手动设置
+import {LayoutConstsMap} from './constants'
 const TmpKey = "HOCKEY"
 
 export default function createElement(comp, props, ...args) {
@@ -33,9 +34,12 @@ export default function createElement(comp, props, ...args) {
 
     const {animation, ref, key, tempName, tempVnode, CPTVnode, datakey, diuu, __source, ...rprops} = props || {}
 
-    // 通用的不支持属性
     if (props.onLayout) {
-        console.warn('小程序不支持onLayout属性')
+        props[LayoutConstsMap.CollectOnLayoutEvent]({
+            id: props[LayoutConstsMap.LayoutEventKey],
+            onLayout: props.onLayout,
+            isRender: false
+        })
     }
     if (typeof props.ref === 'string') {
         console.warn('ref只支持函数形式，不支持字符串')

--- a/packages/wx-react/src/createElement.js
+++ b/packages/wx-react/src/createElement.js
@@ -6,8 +6,8 @@
  *
  */
 
-// 一般情况下 uuid都应该是存在的， 但是HOC的包裹的组件，uuid需要手动设置
 import {LayoutConstsMap} from './constants'
+// 一般情况下 uuid都应该是存在的， 但是HOC的包裹的组件，uuid需要手动设置
 const TmpKey = "HOCKEY"
 
 export default function createElement(comp, props, ...args) {


### PR DESCRIPTION
方案：
编译时：将元素做一个标识，并在生成wxml通过此标识生成id

运行时：通过createElement收集当前所有onLayout事件，并在setState回调中检测是否需要触发onLayout事件