### PR TITLE
webpack新增致命的错误（配置错误）的提示

### DIFF
--- a/packages/alita-core/src/packByWebpack/index.ts
+++ b/packages/alita-core/src/packByWebpack/index.ts
@@ -233,6 +233,10 @@ export default function packByWebpack() {
 }
 
 function runCb(err, stats) {
+    if (err) {
+        handleWebpackError(err)
+        return
+    }
     const info = stats.toJson();
 
     if (stats.hasWarnings()) {
@@ -251,6 +255,10 @@ function runCb(err, stats) {
 }
 
 function watchCb(err, stats) {
+    if (err) {
+        handleWebpackError(err)
+        return
+    }
     const info = stats.toJson();
 
     if (stats.hasWarnings()) {
@@ -267,6 +275,13 @@ function watchCb(err, stats) {
         console.log(`\n编译完成, 监听文件...`.info)
     }
 
+}
+
+function handleWebpackError (err) {
+    console.log(err.stack || err)
+    if (err.details) {
+        console.error(err.details)
+    }
 }
 
 function handleError(message) {


### PR DESCRIPTION
webpack 构建过程可能会因为配置错误造成的错误，由于之前没有将这类错误打印出来，就会导致排查问题困难。
参照官方写法：http://webpack.html.cn/api/node.html#-error-handling-