### PR TITLE
修复自定义组件最外层退化为block引起部分元素事件无效问题

### DIFF
--- a/packages/alita-core/src/tran/compOutElementToBlock.js
+++ b/packages/alita-core/src/tran/compOutElementToBlock.js
@@ -21,14 +21,29 @@ export default function compOutElementToBlock (ast, info) {
         exit: path => {
             if (path.type === 'JSXOpeningElement'
                 && path.node.name.name === 'view'
-                && getOriginal(path)  // 没有origial属性的view，可能是直接使用的小程序内置组件，这个时候view可能有其他属性，故无法转化为block
                 && isRenderReturn(path)
 				&& !getAttri(path, 'onLayout') // 有onLayout属性的，无法转化为block
             ) {
-                path.node.name.name = 'block'
+                const original = getOriginal(path)
+                /*
+                    没有origial属性的view，可能是直接使用的小程序内置组件，这个时候view可能有其他属性，故无法转化为block
+                    同时也需要满足origial不是为TouchableWithoutFeedback、TouchableOpacity、TouchableHighlight、
+                    AnimatedView、AnimatedImage和AnimatedText，因为origial为这些内容的话，可能需要在view元素绑定一
+                    些事件（比如点击事件），如果退化为block，则事件就失效了
+                */
+                if (original
+                    && original !== 'TouchableWithoutFeedback'
+                    && original !== 'TouchableOpacity'
+                    && original !== 'TouchableHighlight'
+                    && original !== 'AnimatedView'
+                    && original !== 'AnimatedImage'
+                    && original !== 'AnimatedText'
+                ) {
+                    path.node.name.name = 'block'
 
-                if (path.parentPath.node.closingElement) {
-                    path.parentPath.node.closingElement.name.name = 'block'
+                    if (path.parentPath.node.closingElement) {
+                        path.parentPath.node.closingElement.name.name = 'block'
+                    }
                 }
             }
 

--- a/packages/alita-core/src/tran/compOutElementToBlock.js
+++ b/packages/alita-core/src/tran/compOutElementToBlock.js
@@ -55,5 +55,5 @@ export default function compOutElementToBlock (ast, info) {
 
 function hasEventAttri(path) {
     const attris = path.node.attributes
-    return attris.find(attri => /^on/.test(attri))
+    return attris.find(attri => attri.type === 'JSXAttribute' && /^on/.test(attri.name.name))
 }

--- a/packages/alita-core/src/tran/compOutElementToBlock.js
+++ b/packages/alita-core/src/tran/compOutElementToBlock.js
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {isRenderReturn, getOriginal, getAttri} from '../util/uast'
+import {isRenderReturn, getOriginal} from '../util/uast'
 import errorLogTraverse from '../util/ErrorLogTraverse'
+import {viewOrigin, innerTextOrigin, outerTextOrigin} from '../constants'
 
 /**
  * 微信小程序自定义节点会退化为 view， 故把render 直接下的view 替换为block，减少组件层级
@@ -22,22 +23,20 @@ export default function compOutElementToBlock (ast, info) {
             if (path.type === 'JSXOpeningElement'
                 && path.node.name.name === 'view'
                 && isRenderReturn(path)
-				&& !getAttri(path, 'onLayout') // 有onLayout属性的，无法转化为block
             ) {
                 const original = getOriginal(path)
                 /*
                     没有origial属性的view，可能是直接使用的小程序内置组件，这个时候view可能有其他属性，故无法转化为block
-                    同时也需要满足origial不是为TouchableWithoutFeedback、TouchableOpacity、TouchableHighlight、
-                    AnimatedView、AnimatedImage和AnimatedText，因为origial为这些内容的话，可能需要在view元素绑定一
-                    些事件（比如点击事件），如果退化为block，则事件就失效了
+                    有origial情况下，只有当origial为 innerTextOrigin / outerTextOrigin / viewOrigin 这3种，且无
+                    onXXX 属性，才可以转换为block
                 */
                 if (original
-                    && original !== 'TouchableWithoutFeedback'
-                    && original !== 'TouchableOpacity'
-                    && original !== 'TouchableHighlight'
-                    && original !== 'AnimatedView'
-                    && original !== 'AnimatedImage'
-                    && original !== 'AnimatedText'
+                    && (
+                        original === viewOrigin
+                        || original === innerTextOrigin
+                        || original === outerTextOrigin
+                    )
+                    && !hasEventAttri(path)
                 ) {
                     path.node.name.name = 'block'
 
@@ -52,4 +51,9 @@ export default function compOutElementToBlock (ast, info) {
 
     return ast
 
+}
+
+function hasEventAttri(path) {
+    const attris = path.node.attributes
+    return attris.find(attri => /^on/.test(attri))
 }


### PR DESCRIPTION
当origial为TouchableWithoutFeedback、TouchableOpacity等这些值时，自定义组件最外层元素不可以退化为block，因为origial为这些内容的话，可能需要在view元素绑定一些事件（比如点击事件），如果退化为block，则事件就失效了