### PR TITLE
如果cpt变量式子是条件语句的话，则不应该转换为jsx,否则会引起逻辑错误

### DIFF
--- a/packages/alita-core/src/tran/cptCompHandler.js
+++ b/packages/alita-core/src/tran/cptCompHandler.js
@@ -80,6 +80,14 @@ export default function cptCompHandler (ast, info) {
         },
 
         exit: path => {
+            // 如果当前式子是条件语句（if条件语句或者三元条件语句的话），则直接跳过
+            if (path.parentPath
+                && (path.parentPath.type === 'ConditionalExpression' || path.parentPath.type === 'IfStatement') 
+                && path.node === path.parentPath.node.test
+            ) {
+                return
+            }
+
             // 基本组件的 props = xxComponent / renderItem 等
             if (path.type === 'JSXAttribute') {
                 const jsxOp = path.parentPath.node


### PR DESCRIPTION
如果文件出现 this.props.xxComponent ，则alita都会将这种情况转换为对应的cpt JSX 节点，以下情况就不能转换
```
if (this.props.xxComponent) {  // 不可转
}

this.props.xxComponent   // 不可转
? this.props.xxComponent : <xx>...
```

本次修复只考虑if语句和三元语句的条件语句，还有 && 或 || 这两类表达式一般没用，所以就不考虑。
