### PR TITLE
feat(alita-core): 1.移除Platform.OS!=='wx'的条件语句代码 2.移除无用的imports（包括Plat…

### DIFF
--- a/packages/alita-core/src/packByWebpack/gatherInfo-loader.ts
+++ b/packages/alita-core/src/packByWebpack/gatherInfo-loader.ts
@@ -19,6 +19,8 @@ import {isReactComponent, parseCode, isReactFragment} from "../util/uast"
 import {getModuleInfo, setModuleInfo} from '../util/cacheModuleInfos'
 import {getLibCompInfos} from "../util/getAndStorecompInfos";
 import {judgeLibPath} from "../util/util";
+import deleteNoWxCode from "../preproccessCode/deleteNoWxCode"
+import optimizeImports from "../preproccessCode/importOptimize"
 
 /**
  * 收集alita 处理所必须的信息
@@ -30,7 +32,11 @@ export default function (this: webpack.loader.LoaderContext,  context: string): 
     const filepath = this.resourcePath
 
     console.log(`开始处理：${filepath.replace(configure.inputFullpath, '')} ...`.info)
-    const ast = parseCode(context, npath.extname(filepath))
+    let ast = parseCode(context, npath.extname(filepath))
+    //删除非wx平台的代码
+    ast = deleteNoWxCode(ast)
+    //移除无用的的Import，减少import不支持转化的模块导致转化错误（包括移除非wx平台的代码，导致的无用import）
+    ast = optimizeImports(ast)
 
     //TODO 暂时通过此方式，让ast和sourceCode/filepath 建立联系
     // @ts-ignore

--- a/packages/alita-core/src/preproccessCode/deleteNoWxCode.ts
+++ b/packages/alita-core/src/preproccessCode/deleteNoWxCode.ts
@@ -37,7 +37,7 @@ function checkAndRemoveCode(path,isIfStatement,isConditionalExpression){
 		if (isIfStatement && path.node.alternate) {
 			path.replaceWith(path.node.consequent)
 		} else if(isConditionalExpression && path.node.consequent){
-			path.parent.init = path.node.consequent;
+			path.replaceWith(path.node.consequent)
 		} 
 	}
 
@@ -46,7 +46,7 @@ function checkAndRemoveCode(path,isIfStatement,isConditionalExpression){
 		if (isIfStatement && path.node.consequent) {
 			path.node.consequent.body= [];
 		} else if(isConditionalExpression && path.node.alternate){
-			path.parent.init = path.node.alternate
+			path.replaceWith(path.node.alternate)
 		}
   	}
 }

--- a/packages/alita-core/src/preproccessCode/deleteNoWxCode.ts
+++ b/packages/alita-core/src/preproccessCode/deleteNoWxCode.ts
@@ -1,0 +1,63 @@
+import traverse from "@babel/traverse"
+import * as t from '@babel/types'
+
+/**
+ * 删除调非wx平台的代码
+ * if (Platform.OS === 'wx) { ... } else { ... } ===> if (Platform.OS === 'wx) { ... }  ('wx' === Platform.OS) 同理）
+ * if (Platform.OS !== 'wx) { ... } else { ... } ===> if (Platform.OS !== 'wx) {  } else { ... }
+ * let value = Platform.OS === 'wx? value1 : value2 ===> let value = value1
+ * let value = Platform.OS !== 'wx? value2 : value1 ===> let value = value2
+ */
+export default function deleteNoWxCode(ast) {
+    traverse(ast, {
+      	IfStatement(path) {
+        	try {
+				checkAndRemoveCode(path, true, false)
+          	} catch(e) {
+            console.log(e)
+          }
+        }
+	})
+
+	traverse(ast, {
+		ConditionalExpression(path) {
+			try {
+				checkAndRemoveCode(path, false, true)
+			} catch (e) {
+				console.log(e);
+			}
+		}
+	});
+	
+    return ast
+}
+
+function checkAndRemoveCode(path,isIfStatement,isConditionalExpression){
+  	let hasPlatformOS = false; //条件语句存在 Platform.OS
+  	path.traverse({
+		MemberExpression(path) {
+			if (t.isIdentifier(path.node.object, { name: "Platform"}) 
+					&& t.isIdentifier(path.node.property, { name: "OS" })) {
+				hasPlatformOS = true;
+			}
+		}
+  	});
+
+	if (hasPlatformOS && t.isBinaryExpression(path.node.test, { operator: "===" }) 
+			&& (t.isStringLiteral(path.node.test.right, { value: "wx"}) || t.isStringLiteral(path.node.test.left, { value: "wx"}))) {
+		if (isIfStatement && path.node.alternate) {
+			path.node.alternate = null;
+		} else if(isConditionalExpression && path.node.consequent){
+			path.parent.right = path.node.consequent
+		} 
+	}
+
+  	if (hasPlatformOS && t.isBinaryExpression(path.node.test, { operator: "!==" }) 
+			&& (t.isStringLiteral(path.node.test.right, { value: "wx" }) || t.isStringLiteral(path.node.test.left, { value: "wx"}))) {
+		if (isIfStatement && path.node.consequent) {
+			path.node.consequent.body= [];
+		} else if(isConditionalExpression && path.node.alternate){
+			path.parent.right = path.node.alternate
+		}
+  	}
+}

--- a/packages/alita-core/src/preproccessCode/importOptimize/getSpecImport.ts
+++ b/packages/alita-core/src/preproccessCode/importOptimize/getSpecImport.ts
@@ -1,0 +1,70 @@
+/**
+ *  match the syntax like
+ *    `import a from 'a'`
+ *    `import { b, c } from 'a'`
+ */
+
+import * as t from '@babel/types'
+import { defaultIgnoreImportList } from '.';
+
+/**
+ * get identifiers from the code, as follows
+ *
+ *  input:  `import { b, c } from 'a'`
+ *  output: ['b', 'c']
+ *
+ *  input:  `import a from 'a'`
+ *  output: ['a']
+ */
+function getSpecifierIdentifiers(specifiers = [], withPath = false) {
+  	const collection = [];
+  	function loop(path, index) {
+    		const node = path.node
+    		const item = !withPath ? node.local.name : { path, name: node.local.name }
+    		switch (node.type) {
+      			case 'ImportDefaultSpecifier':
+      			case 'ImportSpecifier':
+      			case 'ImportNamespaceSpecifier':
+        				collection.push(item);
+        				break;
+   		 	}
+  }
+  specifiers.forEach(loop);
+
+  return collection;
+}
+
+/**
+ * input: `import a, {b, c as d} from 'where'`
+ * output: [a, b, d]
+ *
+ * input: `import 'where'`
+ * output: undefined
+ */
+export default function getSpecImport(path, opts = {}) {
+  	const source = path.get('source')
+  	const specifiers = path.get('specifiers')
+  	const ignore = defaultIgnoreImportList
+  	if (t.isImportDeclaration(path))  {
+    	if (t.isStringLiteral(source) && (!ignore || !match(ignore, source.node.value))) {
+      		if (specifiers && specifiers.length > 0) {
+        	return getSpecifierIdentifiers(specifiers, true);
+      		}
+    	}
+  	}
+}
+
+function match (rule, value) {
+  	if (typeof rule === 'string') {
+    	return rule === value
+  	}
+  	if (rule instanceof RegExp) {
+    	return rule.test(value)
+  	}
+  	if (typeof rule === 'function') {
+    	return rule(value)
+  	}
+  	if (Array.isArray(rule)) {
+    	return rule.some(r => match(r, value))
+  	}
+}

--- a/packages/alita-core/src/preproccessCode/importOptimize/index.ts
+++ b/packages/alita-core/src/preproccessCode/importOptimize/index.ts
@@ -1,0 +1,100 @@
+import getSpecImport from './getSpecImport'
+import traverse from "@babel/traverse"
+import * as t from '@babel/types'
+
+export const defaultIgnoreImportList = ['react']
+
+//移除无用的的Import，减少 import不支持的转化的模块导致转化错误
+export default function optimizeImports(ast) {
+	let runtimeData ={}
+	//移除无用的Import
+	traverse(ast, {
+		Program(path) {
+			path.traverse(importTraverseObject, {runtimeData: runtimeData});
+        	handleRemovePath(runtimeData)
+		}
+	})
+	return ast
+}
+
+const idTraverseObject = {
+  	JSXIdentifier(path, {runtimeData}) {
+      	const { parentPath } = path
+      	const { name } = path.node
+
+    	if ( parentPath.isJSXOpeningElement() && parentPath.get('name') === path
+      			|| parentPath.isJSXMemberExpression() && parentPath.get('object') === path) {
+			if (runtimeData[name]) {
+				delete runtimeData[name]
+			}
+		}
+	},
+  	Identifier(path, {runtimeData}) {
+    	const { parentPath } = path
+    	const { name } = path.node
+    	// const ID = 'value';
+    	if (parentPath.isVariableDeclarator() && parentPath.get('id') === path) {}
+		// const x = { Tabs: 'value' }
+		else if (parentPath.isObjectProperty() && parentPath.get('key') === path) {}
+		// { Tabs: 'value' }
+		else if (parentPath.isLabeledStatement() && parentPath.get('label') === path) {}
+		// ref.ID
+		else if (parentPath.isMemberExpression()&& parentPath.get('property') === path && parentPath.node.computed === false) {}
+		// class A { ID() {} }
+		else if ((parentPath.isClassProperty() || parentPath.isClassMethod()) && parentPath.get('key') === path) {}
+		else {
+			// used
+			if (runtimeData[name]) {
+				delete runtimeData[name]
+			}
+		}
+  }
+}
+
+const importTraverseObject = {
+	ImportDeclaration(path, data) {
+		const { opts = {}, runtimeData } = data
+		path.skip()
+		const locals = getSpecImport(path, { withPath: true, ignore: opts.ignore });
+		if (locals) {
+			locals.forEach((pathData, index, all) => {
+				const { name } = pathData
+				if (runtimeData[name]) {
+					return
+				}
+				runtimeData[name] = {
+					parent: path,
+					children: all,
+					data: pathData
+				}
+			})
+		}
+	},
+	...idTraverseObject
+}
+
+function handleRemovePath(runtimeData, opts = {}) {
+	/*
+	{
+	parent: path,
+	children: [ { path, name } ],
+	data: { path, name }
+	}
+	*/
+	const allNames = Object.keys(runtimeData)
+	allNames.forEach(name => {
+		const {children, data, parent} = runtimeData[name]
+		const childNames = children.map(x => x.name)
+		// every imported identifier is unused
+		if (childNames.every(cName => allNames.includes(cName))) {
+			!parent.__removed && parent.remove();
+			parent.__removed = true
+		} else {
+			const path = data.path
+			!path.__removed && path.remove();
+			path.__removed = true
+		}
+	})
+}
+
+

--- a/packages/alita-core/src/preproccessCode/importOptimize/index.ts
+++ b/packages/alita-core/src/preproccessCode/importOptimize/index.ts
@@ -91,8 +91,7 @@ function handleRemovePath(runtimeData, opts = {}) {
 			parent.__removed = true
 		} else {
 			const path = data.path
-			!path.__removed && path.remove();
-			path.__removed = true
+			path.remove();
 		}
 	})
 }


### PR DESCRIPTION
1、 移除非wx平台的代码，减少包大小，
例如：
 * if ( Platform.OS === 'wx' ) { ... } else { ... }    ===>    if (Platform.OS === 'wx) { ... }  
 * let value = Platform.OS === 'wx' ? value1 : value2   ===>   let value = value1
*  'wx' === Platform.OS,   'wx' !== Platform.OS , Platform.OS !== 'wx'  都有处理
 

2、在代码处理前 移除无用的imports（包括Platform.OS!=='wx'移除导致的无用imports)，减少转化失败  

例如: 

if ( Platform.OS !== 'wx' ){ 此处用到一个桥接Native的组件}，即使移除这块代码了，还是会imports 这个组件，导致转化失败，需要把相关的imports移除掉，那么可以通过Platform.OS写差异代码又不会导致转化失败