### PR TITLE
通过静态分析减小wxml大小

### DIFF
--- a/fixtures/sizeRNvsMPvsAlita/src/CommonPage.js
+++ b/fixtures/sizeRNvsMPvsAlita/src/CommonPage.js
@@ -17,6 +17,12 @@ export default class CommonPage extends Component {
 						history.push('Page1')
 					}}
 				/>
+                <Button
+					title={"to Page2"}
+					onPress={() => {
+						history.push('Page2')
+					}}
+				/>
             </View>
 
         );

--- a/fixtures/sizeRNvsMPvsAlita/src/Page2.js
+++ b/fixtures/sizeRNvsMPvsAlita/src/Page2.js
@@ -1,0 +1,101 @@
+import React, { Component } from "react";
+import { StyleSheet, Text, View, Platform } from "react-native"
+
+/*
+    经过静态解析方式，以下代码由原来会生成以下6块代码段减少到0块
+    <template name="c">
+        <block wx:if="{{_t.l(d)}}">{{d}}</block>
+        <_g wx:elif="{{d._generic}}" diuu="{{d._generic}}" style="{{_t.s(d._genericstyle)}}"/>
+        <template wx:elif="{{d.tempName}}" is="{{d.tempName}}" data="{{...d}}"/>
+        <block wx:else>
+            <block wx:for="{{d}}" wx:key="key">
+                <block wx:if="{{_t.l(item)}}">{{item}}</block>
+                <_g wx:elif="{{item._generic}}" diuu="{{item._generic}}" style="{{_t.s(item._genericstyle)}}"/>
+                <template wx:else is="{{item.tempName}}" data="{{...item}}"/>
+            </block>
+        </block>
+    </template>
+ */
+
+const styles = StyleSheet.create({
+    container: {
+        textAlign: 'center',
+        paddingTop: 50
+    },
+    red: {
+        color: 'red',
+        fontSize: 20
+    },
+    blue: {
+        color: 'blue',
+        fontSize: 20
+    }
+});
+
+
+export default class Page2 extends Component {
+    a() {
+        return (
+            <View>
+                {this.b()}
+            </View>
+        )
+    }
+
+    b() {
+        return (
+            <View>
+                {this.c()}
+            </View>
+        )
+    }
+
+    c() {
+        return (
+            <View>
+                <Text style={styles.red}>
+                    ccc
+                </Text>
+            </View>
+        )
+    }
+
+    render() {
+        const d = <View><Text style={styles.blue}>ddd</Text></View>
+        let e = null
+        e = <View><Text style={styles.red}>eee</Text></View>
+        const isTrue = true
+
+        return (
+            <View style={styles.container}>
+                <View>
+                    {this.a()}
+                    {this.c()}
+                    <View>
+                        <View>
+                            {d}
+                            {e}
+                            <View>
+                                {
+                                    isTrue && d
+                                }
+                                {
+                                    isTrue && this.c()
+                                }
+                                <View>
+                                    {
+                                        isTrue ? d : e
+                                    }
+                                    {
+                                        isTrue ? this.c() : e
+                                    }
+                                </View>
+                            </View>
+                        </View>
+                    </View>
+                </View>
+            </View>
+        );
+    }
+}
+

--- a/fixtures/sizeRNvsMPvsAlita/src/index.js
+++ b/fixtures/sizeRNvsMPvsAlita/src/index.js
@@ -13,6 +13,7 @@ import React, {PureComponent} from 'react'
 import {Router, Route, TabRouter} from '@areslabs/router'
 
 import Page1 from './Page1'
+import Page2 from './Page2'
 import CommonPage from './CommonPage'
 
 import {f1} from './util'
@@ -42,6 +43,7 @@ export default class App extends PureComponent {
 
 				{/*分包用来测试体积*/}
                 <Route subpage="one" key={"Page1"} component={Page1}/>
+                <Route subpage="two" key={"Page2"} component={Page2}/>
             </Router>
         )
     }

--- a/packages/alita-core/src/tran/addTempName.js
+++ b/packages/alita-core/src/tran/addTempName.js
@@ -215,7 +215,7 @@ function checkFuncIsJsx(expression, ast) {
  */
 function checkVarnIsJsx(varnName, ast) {
 	let isJsxExpress = false
-	let varnNameCount = 0 // ele.expression.name 已经算了一次了，所以从-1算起
+	let varnNameCount = 0
 	errorLogTraverse(ast, {
 		exit: (path) => {
 			if ((

--- a/packages/alita-core/src/tran/addTempName.js
+++ b/packages/alita-core/src/tran/addTempName.js
@@ -19,80 +19,332 @@ export default function addTempName (ast, info) {
 
 	errorLogTraverse(ast, {
         exit: path => {
-            if (path.type === 'JSXElement'
-                && (!isJSXChild(path) || isChildCompChild(path, info.filepath))
-            ) {
-                const jsxOp = path.node.openingElement
+					if (path.type === 'JSXElement'
+							&& (!isJSXChild(path) || isChildCompChild(path, info.filepath))
+					) {
+							const jsxOp = path.node.openingElement
 
-                const tempName = tempNameCount.next
-                jsxOp.attributes.push(t.jsxAttribute(t.jsxIdentifier('tempName'), t.stringLiteral(tempName)))
-            }
-
-
-			// 如果只使用一个child 小程序会报递归， 然后就不渲染了
-			if (path.type === 'JSXElement'
-				&& !isChildComp(path.node.openingElement.name.name, info.filepath)
-			) {
-				const children = path.node.children
-				let tempName = null
-
-				const isTextEle = isTextElement(path.node.openingElement)
-
-				path.node.children = children.map(ele => {
-					if (ele.type === 'JSXExpressionContainer') {
-
-						if (!tempName) {
-							tempName = tempNameCount.next
-						}
-
-						const datakey = datakeyCount.next
-
-
-						const templateAttris = [
-							t.jsxAttribute(t.jsxIdentifier('datakey'), t.stringLiteral(datakey)),
-							t.jsxAttribute(t.jsxIdentifier('tempVnode'), ele),
-							t.jsxAttribute(t.jsxIdentifier('wx:if'), t.stringLiteral(`{{${datakey}}} !== undefined`)),
-							t.jsxAttribute(t.jsxIdentifier('is'), t.stringLiteral(tempName)),
-							t.jsxAttribute(t.jsxIdentifier('data'), t.stringLiteral(`{{d: ${datakey}}}`))
-						]
-
-						if (isTextEle) {
-							templateAttris.push(t.jsxAttribute(t.jsxIdentifier('isTextElement')))
-						}
-
-						return t.jsxElement(
-							t.jsxOpeningElement(
-								t.jsxIdentifier('template'),
-								templateAttris
-							),
-							t.jsxClosingElement(
-								t.jsxIdentifier('template')
-							),
-							[],
-							true
-						)
+							const tempName = tempNameCount.next
+							jsxOp.attributes.push(t.jsxAttribute(t.jsxIdentifier('tempName'), t.stringLiteral(tempName)))
 					}
-					return ele
-				})
-
-				if (tempName && !isTextEle) {
-					info.childTemplates.push(tempName)
-				}
-			}
 
 
-            if (path.type === 'JSXOpeningElement') {
-                const jsxOp = path.node
+					// 如果只使用一个child 小程序会报递归， 然后就不渲染了
+					if (path.type === 'JSXElement'
+						&& !isChildComp(path.node.openingElement.name.name, info.filepath)
+					) {
+						const children = path.node.children
+						let tempName = null
 
-                const key = diuuCount.next
+						const isTextEle = isTextElement(path.node.openingElement)
 
-                jsxOp.attributes.push(
-                    t.jsxAttribute(t.jsxIdentifier('diuu'), t.stringLiteral(key))
-                )
-            }
+						path.node.children = children.map(ele => {
+							if (ele.type === 'JSXExpressionContainer') {
+								ele.isJsxExpress = false
+
+								// 以下几种情况，不用生成动态wxml来判断当前节点类型
+								// 1. 如果JSXExpressionContainer为{this.xxx()}，且xxx()方法返回的类型
+								// 		都为JSXElement，则直接生成对应的template
+								if (ele.expression && ele.expression.type === 'CallExpression') {
+									const expression = ele.expression
+									ele.isJsxExpress = checkFuncIsJsx(expression, ast)
+								} 
+								// 2. 如果JSXExpressionContainer为{<xxx></xxx>}，则直接生成对应的template
+								else if (ele.expression && ele.expression.type === 'JSXElement') {
+									ele.isJsxExpress = true
+								}
+								// 3. 如果JSXExpressionContainer为{a}，且a类型为JSXElement，则直接生成对应
+								//    的template
+								else if (ele.expression && ele.expression.type === 'Identifier') {
+									const varnName = ele.expression.name
+									ele.isJsxExpress = checkVarnIsJsx(varnName, ast)
+								}
+								// 4. 如果JSXExpressionContainer为{yyy && <xxx></xxx>}，且则直接生成对应的
+								//    template
+								else if (ele.expression && ele.expression.type === 'LogicalExpression') {
+									ele.isJsxExpress = checkLogiIsJsx(ele.expression, ast)
+								}
+								// 5. 如果JSXExpressionContainer为{aaa ? <xxx></xxx> : <yyy></yyy>}，且则直
+								// 		接生成对应的template
+								else if (ele.expression && ele.expression.type === 'ConditionalExpression') {
+									if (checkExpressionIsJsx(ele.expression.consequent, ast)
+										&& checkExpressionIsJsx(ele.expression.alternate, ast)
+									) {
+										ele.isJsxExpress = true
+									}
+								}
+
+								let templateAttris = []
+								const datakey = datakeyCount.next
+								templateAttris = [
+									t.jsxAttribute(t.jsxIdentifier('datakey'), t.stringLiteral(datakey)),
+									t.jsxAttribute(t.jsxIdentifier('tempVnode'), ele),
+								]
+
+								if (ele.isJsxExpress) {
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('wx:if'), t.stringLiteral(`{{${datakey} && ${datakey}.tempName}}`))
+									)
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('is'), t.stringLiteral(`{{${datakey}.tempName}}`))
+									)
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('data'), t.stringLiteral(`{{...${datakey}}}`))
+									)
+								} else {
+									if (!tempName) {
+										tempName = tempNameCount.next
+									}
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('wx:if'), t.stringLiteral(`{{${datakey}}} !== undefined`))
+									)
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('is'), t.stringLiteral(tempName))
+									)
+									templateAttris.push(
+										t.jsxAttribute(t.jsxIdentifier('data'), t.stringLiteral(`{{d: ${datakey}}}`))
+									)
+								}
+								
+								ele.isJsxExpress = false
+
+								if (isTextEle) {
+									templateAttris.push(t.jsxAttribute(t.jsxIdentifier('isTextElement')))
+								}
+
+								return t.jsxElement(
+									t.jsxOpeningElement(
+										t.jsxIdentifier('template'),
+										templateAttris
+									),
+									t.jsxClosingElement(
+										t.jsxIdentifier('template')
+									),
+									[],
+									true
+								)
+							}
+							return ele
+						})
+
+						if (tempName && !isTextEle) {
+							info.childTemplates.push(tempName)
+						}
+					}
+
+
+					if (path.type === 'JSXOpeningElement') {
+							const jsxOp = path.node
+
+							const key = diuuCount.next
+
+							jsxOp.attributes.push(
+									t.jsxAttribute(t.jsxIdentifier('diuu'), t.stringLiteral(key))
+							)
+					}
         }
     })
-
     return ast
+}
 
+
+/**
+ * 判断方法返回的结果是否是JSX类型
+ * @param {*} expression 
+ * @param {*} ast 
+ */
+function checkFuncIsJsx(expression, ast) {
+	let isJsxExpress = false
+	if (expression.callee
+		&&expression.callee.type === 'MemberExpression'
+		&& expression.callee.object
+		&& expression.callee.object.type === 'ThisExpression'
+		&& expression.callee.property
+		&& expression.callee.property.type === 'Identifier'
+	) {
+		const funcName = expression.callee.property.name
+	
+		errorLogTraverse(ast, {
+			exit: path => {
+				if ((path.node.type === 'ClassMethod'
+					&& path.node.key
+					&& path.node.key.type === 'Identifier'
+					&& path.node.key.name === funcName
+					&& path.node.body.type === 'BlockStatement')
+					|| (
+						path.node.type === 'ClassProperty'
+						&& path.node.key
+						&& path.node.key.type === 'Identifier'
+						&& path.node.key.name === funcName
+						&& path.node.value
+						&& path.node.value.type === 'ArrowFunctionExpression'
+					)
+				) {
+					let runturnIsJsx = true
+					let runturnCount = 0
+
+					path.traverse({
+						ReturnStatement(path) {
+							runturnCount++
+							if (path.node.argument
+								&& path.node.argument.type !== 'NullLiteral'
+								&& !checkExpressionIsJsx(path.node.argument, ast)
+							) {
+								runturnIsJsx = false
+								path.skip()
+							}
+						}
+					})
+
+					if (!runturnIsJsx || (runturnIsJsx && runturnCount === 0)) {
+						isJsxExpress = false
+					} else {
+						isJsxExpress = true
+					}
+				}
+			}
+		})
+	}
+	return isJsxExpress
+}
+
+/**
+ * 判断变量是否是JSX类型
+ * @param {*} varnName 
+ * @param {*} ast 
+ */
+function checkVarnIsJsx(varnName, ast) {
+	let isJsxExpress = false
+	let varnNameCount = 0 // ele.expression.name 已经算了一次了，所以从-1算起
+	errorLogTraverse(ast, {
+		exit: (path) => {
+			if ((
+					path.node.type === 'VariableDeclarator'
+					&& path.node.id
+					&& path.node.id.type === 'Identifier'
+					&& path.node.id.name === varnName
+				)
+					|| (
+					path.node.type === 'AssignmentExpression'
+					&& path.node.operator === '='
+					&& path.node.left 
+					&& path.node.left.type === 'Identifier'
+					&& path.node.left.name === varnName
+				)
+			) {
+				varnNameCount++
+			}
+		}
+	})
+	if (varnNameCount === 1) {
+			errorLogTraverse(ast, {
+				exit: (path) => {
+					if (path.node.type === 'VariableDeclarator'
+						&& path.node.id
+						&& path.node.id.type === 'Identifier'
+						&& path.node.id.name === varnName
+						&& path.node.init
+						&& checkEquationIsJSX(path.node.init, ast)
+					) {
+						isJsxExpress = true
+					}
+				}
+			})
+	} else if (varnNameCount > 1) {
+		let declCount = 0
+		errorLogTraverse(ast, {
+			exit: (path) => {
+				if (path.node.type === 'VariableDeclarator'
+					&& path.node.id
+					&& path.node.id.type === 'Identifier'
+					&& path.node.id.name === varnName
+				) {
+					declCount++
+				}
+			}
+		})
+		if (declCount === 1) {
+			let varnIsJsx = true
+			errorLogTraverse(ast, {
+				exit: (path) => {
+					if (path.node.type === 'AssignmentExpression'
+						&& path.node.operator === '='
+						&& path.node.left 
+						&& path.node.left.type === 'Identifier'
+						&& path.node.left.name === varnName
+						&& path.node.right
+						&& !checkEquationIsJSX(path.node.right, ast)
+					) {
+						varnIsJsx = false
+					}
+				}
+			})
+			if (varnIsJsx) {
+				isJsxExpress = true
+			}
+		}
+	}
+	return isJsxExpress
+}
+
+/**
+ * 判断 xx && yy 的结果是否为JSX类型
+ * @param {*} node 
+ * @param {*} ast 
+ */
+function checkLogiIsJsx(node, ast) {
+	if (node.left
+		&& checkExpressionIsJsx(node.right, ast)
+	) {
+		return true
+	}
+	return false
+}
+
+/**
+ * 判断等式右边结果是否为JSX类型
+ * @param {*} node
+ * @param {*} ast
+ */
+function checkEquationIsJSX(node, ast) {
+	if (
+		node.type === 'JSXElement'
+		|| (
+			node.type === 'CallExpression'
+			&& checkFuncIsJsx(node, ast)
+		)
+		|| (
+			node.type === 'LogicalExpression'
+			&& checkLogiIsJsx(node, ast)
+		)
+		|| (
+			node.type === 'ConditionalExpression'
+			&& checkExpressionIsJsx(node.consequent, ast)
+			&& checkExpressionIsJsx(node.alternate, ast)
+		)
+	) {
+		return true
+	}
+	return false
+}
+
+/**
+ * 判断式子是否是JSX类型，分别判断以下三种情况
+ * 1. 如果为<xxx></xxx>，则是JSX类型
+ * 2. 如果是方法，如this.xx()，判断this.xx()方法返回的是否是JSX类型
+ * 3. 如果是变量，如 x ，判断 x 变量是否是JSX类型
+ * @param {*} node 
+ * @param {*} ast 
+ */
+function checkExpressionIsJsx(node, ast) {
+	if (node.type === 'JSXElement'
+		|| checkFuncIsJsx(node, ast)
+		|| (
+			node.type === 'Identifier'
+			&& checkVarnIsJsx(node.name, ast)
+		)
+	) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
alita 在JSX碰到 {} 这种语法块，会生成一块动态化模板片段，即：

```
<template name="c">
        <block wx:if="{{_t.l(d)}}">{{d}}</block>
        <_g wx:elif="{{d._generic}}" diuu="{{d._generic}}" style="{{_t.s(d._genericstyle)}}"/>
        <template wx:elif="{{d.tempName}}" is="{{d.tempName}}" data="{{...d}}"/>
        <block wx:else>
            <block wx:for="{{d}}" wx:key="key">
                <block wx:if="{{_t.l(item)}}">{{item}}</block>
                <_g wx:elif="{{item._generic}}" diuu="{{item._generic}}" style="{{_t.s(item._genericstyle)}}"/>
                <template wx:else is="{{item.tempName}}" data="{{...item}}"/>
            </block>
        </block>
  </template>
``` 

大多数情况下，上面动态化模板会命中 `<template wx:elif="{{d.tempName}}" is="{{d.tempName}}" data="{{...d}}"/>`，
所以可以针对这种情况，做下静态解析优化，如果在静态解析就知道  {} 会转换为  `<template wx:elif="{{d.tempName}}" is="{{d.tempName}}" data="{{...d}}"/>`，则直接生成，就不需要生成上面的动态化模板，从而减少包大小。
